### PR TITLE
Exit early with useful error message when 'build_failed' is true

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,10 @@ inputs:
     description: 'Time in milliseconds between two deployment status report (default: 1 second)'
     required: false
     default: "1000"
+  build_failed:
+    description: 'True if the previous build step failed'
+    required: false
+    default: false
 outputs:
   page_url:
     description: 'URL to deployed Github Pages'

--- a/src/index.js
+++ b/src/index.js
@@ -52,4 +52,8 @@ process.on('SIGINT', cancelHandler)
 process.on('SIGTERM', cancelHandler)
 
 // Main
-main().then(() => require('./pre'))
+if (core.getInput('build_failed')) {
+  core.setFailed('Deployment skipped due to failed build.')
+} else {
+  main().then(() => require('./pre'))
+}


### PR DESCRIPTION
Adds a new input 'build_failed' which, when true, causes the deploy action
to exit early with a useful error message. Without this, when a build fails
and the deploy step runs after it, the error message refers to a build
artifact not being found, and can confuse a reader.