### PR TITLE
Add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @actions/pages


### PR DESCRIPTION
This PR adds a `CODEOWNERS` file. We use the `CODEOWENRS` file to identify the teams maintaining each open source action in this organization.