### PR TITLE
Update Action name to enable Marketplace publishing

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,6 @@
-name: 'Deploy to GitHub Pages'
+name: 'GitHub Pages Deployment'
 description: 'A GitHub Action to deploy an artifact to GitHub Pages'
+author: 'GitHub'
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
-name: 'GitHub Pages Deployment'
-description: 'A GitHub Action to deploy an artifact to GitHub Pages'
+name: 'Deploy GitHub Pages site'
+description: 'A GitHub Action to deploy an artifact as a GitHub Pages site'
 author: 'GitHub'
 runs:
   using: 'node16'


### PR DESCRIPTION
For better or worse, the GitHub Marketplace requires that each Action published to it has a unique name. Unfortunately for us, the Action name `Deploy to GitHub Pages` is already taken:

<img width="763" alt="image" src="https://user-images.githubusercontent.com/417751/183802570-1229d823-ae55-4215-a3cb-a1e3b2254b81.png">

We need to modify our Action's name in order to be able to publish it to the Marketplace. In this PR, I've suggested changing it to: `GitHub Pages Deployment`.

**Alternative name ideas:**
- `Deploy to Pages`
  - We don't include the word `GitHub` in our other Pages Actions, so this might pass 🤔 
- `Deploy to GitHub Pages (Official)`
- `Deploy artifact to GitHub Pages`
- `Deploy Pages artifact`
  - Symmetrical with [the `Upload Pages artifact` Action](https://github.com/actions/upload-pages-artifact/blob/main/action.yml#L1)

Thoughts? 🤔💭 