### PR TITLE
Remove check for `pre/` distributables

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -42,9 +42,3 @@ jobs:
             git diff
             exit 1
           fi
-
-          if [ "$(git diff --ignore-space-at-eol pre/ | wc -l)" -gt "0" ]; then
-            echo "Detected uncommitted changes after build in pre folder. See status below:"
-            git diff
-            exit 1
-          fi


### PR DESCRIPTION
Following PR #75, we no longer produce a `pre/` distributables directory. As such, our Actions workflow can stop trying to verify it as well. 👍🏻 