### PR TITLE
Add a workflow to rebuild the distributables for Dependabot PRs

### DIFF
--- a/.github/workflows/rebuild-dependabot-prs.yml
+++ b/.github/workflows/rebuild-dependabot-prs.yml
@@ -3,7 +3,7 @@ name: Rebuild distributables for Dependabot PRs
 on:
   push:
     branches:
-       - 'dependabot/npm**'
+      - 'dependabot/npm**'
 
 permissions:
   contents: write

--- a/.github/workflows/rebuild-dependabot-prs.yml
+++ b/.github/workflows/rebuild-dependabot-prs.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           if [ "$(git diff --ignore-space-at-eol dist/ | wc -l)" -gt "0" ]; then
             echo "Detected uncommitted changes after rebuild in dist folder. Committing..."
-	    git add dist/
+            git add dist/
             git config --local user.name "github-actions[bot]"
             git config --local user.email "github-actions[bot]@users.noreply.github.com"
             git commit -m "Update distributables after Dependabot 🤖"

--- a/.github/workflows/rebuild-dependabot-prs.yml
+++ b/.github/workflows/rebuild-dependabot-prs.yml
@@ -2,8 +2,8 @@ name: Rebuild distributables for Dependabot PRs
 
 on:
   push:
-		branches:
-			- 'dependabot/npm**'
+    branches:
+       - 'dependabot/npm**'
 
 permissions:
   contents: write
@@ -37,10 +37,10 @@ jobs:
         run: |
           if [ "$(git diff --ignore-space-at-eol dist/ | wc -l)" -gt "0" ]; then
             echo "Detected uncommitted changes after rebuild in dist folder. Committing..."
-	          git add dist/
-						git config --local user.name "github-actions[bot]"
-						git config --local user.email "github-actions[bot]@users.noreply.github.com"
-						git commit -m "Update distributables after Dependabot 🤖"
-						echo "Pushing branch ${{ github.ref_name }}"
-						git push origin ${{ github.ref_name }}
-					fi
+	    git add dist/
+            git config --local user.name "github-actions[bot]"
+            git config --local user.email "github-actions[bot]@users.noreply.github.com"
+            git commit -m "Update distributables after Dependabot 🤖"
+            echo "Pushing branch ${{ github.ref_name }}"
+            git push origin ${{ github.ref_name }}
+          fi

--- a/.github/workflows/rebuild-dependabot-prs.yml
+++ b/.github/workflows/rebuild-dependabot-prs.yml
@@ -1,0 +1,46 @@
+name: Rebuild distributables for Dependabot PRs
+
+on:
+  push:
+		branches:
+			- 'dependabot/npm**'
+
+permissions:
+  contents: write
+
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
+jobs:
+  rebuild-dist:
+    if: ${{ github.event.sender.login == 'dependabot[bot]' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Node.JS
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Rebuild the dist/ directory
+        run: npm run prepare
+
+      - name: Commit any differences present in the dist/ directory
+        run: |
+          if [ "$(git diff --ignore-space-at-eol dist/ | wc -l)" -gt "0" ]; then
+            echo "Detected uncommitted changes after rebuild in dist folder. Committing..."
+	          git add dist/
+						git config --local user.name "github-actions[bot]"
+						git config --local user.email "github-actions[bot]@users.noreply.github.com"
+						git commit -m "Update distributables after Dependabot 🤖"
+						echo "Pushing branch ${{ github.ref_name }}"
+						git push origin ${{ github.ref_name }}
+					fi


### PR DESCRIPTION
Any Dependabot PRs that change a dependency used in the main code, or in building the main code, will inevitably have 1 failing check because the underlying distributable output won't match anymore.

To streamline getting those Dependabot PRs merged sooner rather than later, I'm introducing a new workflow that will hopefully remove the need for our manual intervention in rebuilding those distributables. 🤞🏻 