### PR TITLE
Update rebuilding workflow to utilize an org-owned PAT

### DIFF
--- a/.github/workflows/rebuild-dependabot-prs.yml
+++ b/.github/workflows/rebuild-dependabot-prs.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.PAGES_AUTOMATION_PAT }}
 
       - name: Setup Node.JS
         uses: actions/setup-node@v3


### PR DESCRIPTION
Because an action (such as pushing a commit) taken by the Actions `GITHUB_TOKEN` is not allowed to trigger another Actions workflow run, resulting in unmergeable Dependabot PRs since the CI checks cannot be run. 🙅🏻 