### PR TITLE
Separate use of Release Drafter

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -1,0 +1,17 @@
+name: Draft release
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  draft-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,9 +23,3 @@ jobs:
 
       - name: Run tests
         run: npm run test
-
-      # Drafts your next Release notes as Pull Requests are merged into "main"
-      - uses: release-drafter/release-drafter@v5
-        if: github.ref_name == 'main'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,13 @@
 name: Run Tests
+
 on:
   push:
     branches:
       - main
   pull_request:
+
+permissions:
+  contents: read
 
 jobs:
   test:


### PR DESCRIPTION
For whatever reason, our current use of Release Drafter was tagged onto the end of the CI testing workflow. 🤷🏻‍♂️ 

Let's give it a dedicated workflow of its own.

Copy of https://github.com/actions/configure-pages/blob/main/.github/workflows/draft-release.yml