### PR TITLE
Deprecate the `conclusion` parameter for the Action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,7 @@ inputs:
     required: false
     default: 'false'
   conclusion:
+    deprecationMessage: 'Use of this input does nothing as it was part of the deprecated `emit_telemetry` flow. You should remove this parameter from your workflow.'
     description: 'The status of the previous build.'
     required: false
   token:


### PR DESCRIPTION
As the added `deprecationMessage` states:

> Use of this input does nothing as it was part of the deprecated `emit_telemetry` flow. You should remove this parameter from your workflow.

Both the `emit_telemetry` and `conclusion` parameters should be removed when we eventually cut a `v2` release. ⏳ 