### PR TITLE
Revise Dependabot rebuild workflow

### DIFF
--- a/.github/workflows/rebuild-dependabot-prs.yml
+++ b/.github/workflows/rebuild-dependabot-prs.yml
@@ -5,17 +5,20 @@ on:
     branches:
       - 'dependabot/npm**'
 
-permissions:
-  contents: write
-
-# This allows a subsequently queued workflow run to interrupt previous runs
-concurrency:
-  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
-  cancel-in-progress: true
+# No permissions needed for `GITHUB_TOKEN` since we're using a PAT instead
+permissions: {}
 
 jobs:
   rebuild-dist:
     if: ${{ github.event.sender.login == 'dependabot[bot]' }}
+
+    # This allows a subsequently queued workflow run to interrupt previous runs.
+    # It is evaluated AFTER the job's `if` condition, so a push triggered by this
+    # workflow's PAT will NOT interrupt a run triggered by a push from Dependabot.
+    concurrency:
+      group: '${{ github.workflow }} / ${{ github.job }} @ ${{ github.ref }}'
+      cancel-in-progress: true
+
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Streamlining.

Changes:
- Don't grant `GITHUB_TOKEN` any permissions -- we never use it.
- Move the `concurrency` configuration into the job so it gets evaluated _AFTER_ the job's `if` configuration
  - Also add the job name into the `concurrency.group` expression for the appropriate level of uniqueness