### PR TITLE
Add GHES compatibility table

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -7,6 +7,8 @@ template: |
   $CHANGES
 
   See details of [all code changes](https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION) since previous release.
+
+  :warning: For use with products other than GitHub.com, such as GitHub Enterprise Server, please consult the [compatibility table](https://github.com/$OWNER/$REPOSITORY/#compatibilty).
 categories:
   - title: '🚀 Features'
     labels:

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -6,6 +6,8 @@ template: |
 
   $CHANGES
 
+  ---
+
   See details of [all code changes](https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION) since previous release.
 
   :warning: For use with products other than GitHub.com, such as GitHub Enterprise Server, please consult the [compatibility table](https://github.com/$OWNER/$REPOSITORY/#compatibilty).

--- a/README.md
+++ b/README.md
@@ -4,6 +4,21 @@
 
 This action is used to deploy [Actions artifacts][artifacts] to [GitHub Pages](https://pages.github.com/).
 
+## Compatibility
+
+This action is primarily design for use with GitHub.com's Actions workflows and Pages deployments. However, certain releases should also be compatible with GitHub Enterprise Server (GHES) `3.7` and above.
+
+| Release | GHES Compatibility |
+|:---|:---|
+| [`v2`](https://github.com/actions/deploy-pages/releases/tag/v2) | 🛑 Incompatible. Anticipating compatibility with `>= 3.9`. |
+| [`v2.0.1`](https://github.com/actions/deploy-pages/releases/tag/v2.0.1) | 🛑 Incompatible. Anticipating compatibility with `>= 3.9`. |
+| [`v2.0.0`](https://github.com/actions/deploy-pages/releases/tag/v2.0.0) | 🛑 Incompatible. Anticipating compatibility with `>= 3.9`. |
+| [`v1`](https://github.com/actions/deploy-pages/releases/tag/v1) | `>= 3.7` |
+| [`v1.2.8`](https://github.com/actions/deploy-pages/releases/tag/v1.2.8) | `>= 3.7` |
+| [`v1.2.7`](https://github.com/actions/deploy-pages/releases/tag/v1.2.7) | :warning: [Incompatible](https://github.com/actions/deploy-pages/issues/137). Anticipating compatibility with `>= 3.9`. |
+| [`v1.2.6`](https://github.com/actions/deploy-pages/releases/tag/v1.2.6) | `>= 3.7` |
+| `v1.x.x` | `>= 3.7` |
+
 ## Usage
 
 See [action.yml](action.yml) for the various `inputs` this action supports.


### PR DESCRIPTION
After seeing multiple recent issues surrounding confusion over support for GitHub Enterprise Server usage, we decided it would be best to document compatibility more explicitly for those customers who are pulled the latest versions from the live repos rather than relying on the GHES-bundled versions. 😅 

Closes #168 

Related:
- #168 
- #137 
- etc.

P.S. Retroactively added the warning into the `v2.0.0` and `v2.0.1` release notes.