### PR TITLE
Remove "beta" disclaimer from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,6 @@ jobs:
 | -------- | ----------- |
 | `GITHUB_PAGES` | This environment variable is created and set to the string value `"true"` so that framework build tools may choose to differentiate their output based on the intended target hosting platform. |
 
-## Scope
-
-⚠️ Official support for building Pages with Actions is in public beta at the moment.
-
 ## Security Considerations
 
 There are a few important considerations to be aware of:


### PR DESCRIPTION
Running Pages deployments on Actions is definitely not a beta feature anymore, and hasn't been [for about a year now](https://github.blog/2022-08-10-github-pages-now-uses-actions-by-default/). 😅 

Let's remove the old "beta" disclaimer. 🚀 