### PR TITLE
Document actions read permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ jobs:
 
     # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
     permissions:
+      actions: read
       pages: write      # to deploy to Pages
       id-token: write   # to verify the deployment originates from an appropriate source
 


### PR DESCRIPTION
According to the release notes for v4, the `actions: read` permission is now needed.
I didn't see any explanation as to why, so if you could add that, this would be even better.