### PR TITLE
[Error message] add file permissions in message 

### DIFF
--- a/src/internal/deployment.js
+++ b/src/internal/deployment.js
@@ -19,7 +19,7 @@ const finalErrorStatus = {
   deployment_failed: 'Deployment failed, try again later.',
   deployment_perms_error: 'Deployment failed. Please ensure that the file permissions are correct.',
   deployment_content_failed:
-    'Artifact could not be deployed. Please ensure the content does not contain any hard links, symlinks and total size is less than 10GB.',
+    'Artifact could not be deployed. Please ensure the content does not contain any hard links, symlinks, have correct file permissions and total size is less than 10GB.',
   deployment_cancelled: 'Deployment cancelled.',
   deployment_lost: 'Deployment failed to report final status.'
 }


### PR DESCRIPTION
Hi

I had an error with file permissions (exactly this one https://github.com/actions/deploy-pages/issues/303#issuecomment-1915616098)

I think we can add the file permissions message to users

```
Artifact could not be deployed. Please ensure the content does not contain any hard links, symlinks and total size is less than 10GB.
```

to

```
Artifact could not be deployed. Please ensure the content does not contain any hard links, symlinks, have correct file permissions and total size is less than 10GB.
```


Related to:
- https://github.com/actions/deploy-pages/issues/303
- https://github.com/actions/upload-pages-artifact
- `file permissions` explained in https://github.com/actions/upload-pages-artifact/blob/main/README.md