### PR TITLE
README(example): remove unecessary step id

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Deploy to GitHub Pages
-        id: deployment
         uses: actions/deploy-pages@v4 # or specific "vX.X.X" version tag for this action
 ```
 


### PR DESCRIPTION
This isn't necessary at all. The step id is only required in the build job.